### PR TITLE
Forbid encryption of public rooms

### DIFF
--- a/room_access_rules/__init__.py
+++ b/room_access_rules/__init__.py
@@ -361,6 +361,9 @@ class RoomAccessRules(object):
             if event.type == EventTypes.Topic:
                 return self._on_room_topic_change(event, rule), None
 
+            if event.type == EventTypes.RoomEncryption:
+                return self._on_room_encryption_change(event, state_events), None
+
         return True, None
 
     async def check_visibility_can_be_modified(
@@ -713,6 +716,23 @@ class RoomAccessRules(object):
             True if the event can be allowed, False otherwise.
         """
         return rule != AccessRules.DIRECT
+
+    def _on_room_encryption_change(
+        self, event: EventBase, state_events: StateMap[EventBase]
+    ) -> bool:
+        """Check whether a room can have its encryption enabled.
+        The current rule is to forbid such a change in public rooms.
+
+        Args:
+            event: The event to check.
+            state_events: A dict mapping (event type, state key) to state event.
+
+        Returns:
+            True if the event can be allowed, False otherwise.
+        """
+        if self._get_join_rule_from_state(state_events) == JoinRules.PUBLIC:
+            return False
+        return True
 
     @staticmethod
     def _get_rule_from_state(state_events: StateMap[EventBase]) -> str:

--- a/room_access_rules/__init__.py
+++ b/room_access_rules/__init__.py
@@ -350,7 +350,7 @@ class RoomAccessRules(object):
                 )
 
             if event.type == EventTypes.JoinRules:
-                return self._on_join_rule_change(event, rule), None
+                return self._on_join_rule_change(event, rule, state_events), None
 
             if event.type == EventTypes.RoomAvatar:
                 return self._on_room_avatar_change(event, rule), None
@@ -657,7 +657,9 @@ class RoomAccessRules(object):
 
         return True
 
-    def _on_join_rule_change(self, event: EventBase, rule: str) -> bool:
+    def _on_join_rule_change(
+        self, event: EventBase, rule: str, state_events: StateMap[EventBase]
+    ) -> bool:
         """Check whether a join rule change is allowed.
 
         A join rule change is always allowed unless the new join rule is "public" and
@@ -672,6 +674,9 @@ class RoomAccessRules(object):
         """
         if event.content.get("join_rule") == JoinRules.PUBLIC:
             return rule != AccessRules.DIRECT
+
+        if self._get_join_rule_from_state(state_events) == JoinRules.PUBLIC:
+            return False
 
         return True
 

--- a/tests/test_event_allowed.py
+++ b/tests/test_event_allowed.py
@@ -611,6 +611,28 @@ class SendEventTestCase(aiounittest.AsyncTestCase):
 
         self.assertTrue(allowed)
 
+    async def test_forbid_join_rule_change_public_room(self):
+        """Tests that the join_rule of a public room can't be changed."""
+        state_events = self.restricted_room_state.copy()
+        state_events[(EventTypes.JoinRules, "")] = MockEvent(
+            sender=self.room_creator,
+            type=EventTypes.JoinRules,
+            content={"join_rule": JoinRules.PUBLIC},
+            state_key="",
+        )
+
+        allowed, _ = await self.module.check_event_allowed(
+            event=MockEvent(
+                sender=self.room_creator,
+                type=EventTypes.JoinRules,
+                content={"join_rule": JoinRules.PRIVATE},
+                state_key="",
+            ),
+            state_events=state_events,
+        )
+
+        self.assertFalse(allowed)
+
     async def test_forbid_encryption_public_room(self):
         """Tests that a public room can't have its encryption enabled."""
         state_events = self.restricted_room_state.copy()

--- a/tests/test_event_allowed.py
+++ b/tests/test_event_allowed.py
@@ -611,6 +611,28 @@ class SendEventTestCase(aiounittest.AsyncTestCase):
 
         self.assertTrue(allowed)
 
+    async def test_forbid_encryption_public_room(self):
+        """Tests that a public room can't have its encryption enabled."""
+        state_events = self.restricted_room_state.copy()
+        state_events[(EventTypes.JoinRules, "")] = MockEvent(
+            sender=self.room_creator,
+            type=EventTypes.JoinRules,
+            content={"join_rule": JoinRules.PUBLIC},
+            state_key="",
+        )
+
+        allowed, _ = await self.module.check_event_allowed(
+            event=MockEvent(
+                sender=self.room_creator,
+                type=EventTypes.RoomEncryption,
+                content={},
+                state_key="",
+            ),
+            state_events=state_events,
+        )
+
+        self.assertFalse(allowed)
+
     async def test_forbidden_users_join(self):
         """Tests that RoomAccessRules.check_event_allowed behaves accordingly.
 


### PR DESCRIPTION
### Description
It also forbids change of join_rule for existing public rooms, otherwise someone can change to private and then enabled encryption, which is what the Android convert button is doing.

### Test
On Dev : 
- public room can not be encrypted 
- external users can not access or be invited in public room nor private rooms
- external users can access only external rooms
- check encryption is enabled on private and external rooms

see test result : https://github.com/tchapgouv/synapse-room-access-rules/pull/1#issuecomment-1944232352

### Deployment progression
see https://github.com/tchapgouv/tchap-infra/pull/2524