### PR TITLE
Fix SQL injection in room-fixer background task

### DIFF
--- a/room_access_rules/__init__.py
+++ b/room_access_rules/__init__.py
@@ -180,16 +180,26 @@ class RoomAccessRules(object):
             limit: Optional[int] = None,
             from_id: Optional[str] = None,
         ) -> List[str]:
-            limit_statement = ""
-            if limit is not None:
-                limit_statement = f"LIMIT {limit}"
+            # room_id values are not constrained to a safe character set (a
+            # room created on a federated homeserver can contain arbitrary
+            # characters, including quotes), so they must never be
+            # interpolated into the SQL string. Use bound parameters for
+            # both the pagination cursor and the limit.
+            args: List[Any] = []
 
             where_statement = ""
             if from_id:
-                where_statement = f"WHERE room_id > '{from_id}'"
+                where_statement = "WHERE room_id > ?"
+                args.append(from_id)
+
+            limit_statement = ""
+            if limit is not None:
+                limit_statement = "LIMIT ?"
+                args.append(limit)
 
             txn.execute(
-                f"SELECT * FROM rooms {where_statement} ORDER BY room_id {limit_statement}"
+                f"SELECT * FROM rooms {where_statement} ORDER BY room_id {limit_statement}",
+                args,
             )
             rows = txn.fetchall()
             return [r[0] for r in rows]


### PR DESCRIPTION
# Fix SQL injection in the room-fixer background task

## Summary

`get_room_ids_from`, the pagination helper used by the
`fix_existing_rooms_power_levels` / `fix_existing_rooms_visibility_access_rules`
background tasks, builds its SQL by interpolating the pagination cursor
(`from_id`) and `limit` directly into the query string with f-strings:

```python
where_statement = ""
if from_id:
    where_statement = f"WHERE room_id > '{from_id}'"

txn.execute(
    f"SELECT * FROM rooms {where_statement} ORDER BY room_id {limit_statement}"
)
```

`from_id` is a `room_id` value read from the `rooms` table. It is then
carried into `last_room_id`, persisted into the scheduled task's
`result["last_room_id"]`, and fed back into this function as the cursor for
the next pagination batch. Matrix room IDs are **not** constrained to a safe
character set — a room created on a remote homeserver can contain arbitrary
characters in the part before the domain, including single quotes
(`RoomID.is_valid("!x' ... :evil.com")` returns `True`). A room ID containing
a quote therefore breaks out of the string literal and is executed as SQL.

## Impact

When one of the background-fixer features is enabled
(`fix_admins_for_dm_power_levels`, `add_live_location_power_levels`,
`add_matrix_rtc_call_power_levels`, or `fix_visibility_access_rules`), a
crafted `room_id` reaches this query on the pagination batch following the
malicious row. Because `txn.execute` runs a single statement, this is a
read-context (e.g. `UNION` / boolean) injection rather than a stacked-query
primitive: it allows reading arbitrary rows from the database the module can
reach (for example access tokens or E2E room-key backup tables), which is a
confidentiality impact on the homeserver.

CWE-89 (Improper Neutralization of Special Elements used in an SQL Command).

## Preconditions

- One of the four fixer features above is enabled in the module config (all
  default to disabled).
- A `room_id` containing SQL-significant characters exists in the local
  `rooms` table — e.g. a room created by a federated homeserver that the
  local server has become aware of — and it is not the last row in
  `ORDER BY room_id` order, so a subsequent pagination batch uses it as the
  cursor.

## Fix

Use bound parameters for both the pagination cursor and the limit. The
`WHERE` / `LIMIT` fragments now contain only fixed SQL keywords and `?`
placeholders; no value derived from the database is ever concatenated into
the statement.

```python
args: List[Any] = []

where_statement = ""
if from_id:
    where_statement = "WHERE room_id > ?"
    args.append(from_id)

limit_statement = ""
if limit is not None:
    limit_statement = "LIMIT ?"
    args.append(limit)

txn.execute(
    f"SELECT * FROM rooms {where_statement} ORDER BY room_id {limit_statement}",
    args,
)
```

## Verification

- The existing test suite (`tox -e tests`) passes unchanged (30/30).
- With the parameterised query, a `room_id` of the form
  `!a' UNION SELECT token FROM secret_tokens --:evil.com` used as the
  pagination cursor is treated as a literal string value: it returns no
  injected rows and pagination continues correctly.

## Notes

`limit` is currently always an internally supplied integer, but it is bound
as a parameter as well so the helper is safe regardless of caller.

---

Nils Putnins / OffSeq Cybersecurity
npu@offseq.com / https://offseq.com / https://radar.offseq.com