### PR TITLE
fix: force_unencrypted_at_creation and visibility are optional parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,18 @@ modules:
         bypass_for_users: []
 ```
 
+### Configuration Flags
+
+The following boolean flags can be used to enable automatic fixes (jobs) for existing rooms:
+
+* `fix_admins_for_dm_power_levels` (default: `false`): When enabled, automatically sets all members of direct message rooms as admins (power level 100). This ensures both participants have equal administrative rights. Runs once on startup.
+
+* `add_live_location_power_levels` (default: `false`): When enabled, adds power level configuration for live location sharing events (`m.beacon_info` and `org.matrix.msc3672.beacon_info`) if missing, setting them to the default event power level. This allows normal users to use live location sharing by default. Runs once on startup.
+
+* `add_matrix_rtc_call_power_levels` (default: `false`): When enabled, adds power level configuration for Matrix RTC call events (`m.call.member` and `org.matrix.msc3401.call.member`) if missing, setting them to the default event power level. This allows normal users to participate in calls by default. Runs once on startup.
+
+* `fix_visibility_access_rules` (default: `false`): When enabled, automatically updates the `visibility` attribute in the `im.vector.room.access_rules` event for public rooms that are missing this attribute. Runs once on startup.
+
 ## Development and Testing
 
 This repository uses `tox` to run tests.

--- a/room_access_rules/__init__.py
+++ b/room_access_rules/__init__.py
@@ -867,7 +867,7 @@ class RoomAccessRules(object):
             current_force_unencrypted = prev_rules_event.content.get(
                 "force_unencrypted_at_creation", None
             )
-            if new_force_unencrypted != current_force_unencrypted:
+            if new_force_unencrypted is not None and new_force_unencrypted != current_force_unencrypted:
                 return False
 
         # visibility parameter should never be changed after creation of the room
@@ -878,7 +878,7 @@ class RoomAccessRules(object):
             current_visibility = prev_rules_event.content.get(
                 "visibility", None
             )
-            if new_visibility != current_visibility:
+            if new_visibility is not None and new_visibility != current_visibility:
                 return False
 
         new_rule = event.content.get("rule")

--- a/room_access_rules/__init__.py
+++ b/room_access_rules/__init__.py
@@ -861,24 +861,17 @@ class RoomAccessRules(object):
 
         # force_unencrypted_at_creation parameter should never be changed after creation of the room
         if prev_rules_event:
-            new_force_unencrypted = event.content.get(
-                "force_unencrypted_at_creation", None
-            )
-            current_force_unencrypted = prev_rules_event.content.get(
-                "force_unencrypted_at_creation", None
-            )
-            if new_force_unencrypted is not None and new_force_unencrypted != current_force_unencrypted:
+            new_force_unencrypted = event.content.get("force_unencrypted_at_creation")
+            current_force_unencrypted = prev_rules_event.content.get("force_unencrypted_at_creation")
+            if current_force_unencrypted is not None and new_force_unencrypted is not None and new_force_unencrypted != current_force_unencrypted:
                 return False
 
         # visibility parameter should never be changed after creation of the room
         if prev_rules_event:
-            new_visibility = event.content.get(
-                "visibility", None
-            )
-            current_visibility = prev_rules_event.content.get(
-                "visibility", None
-            )
-            if new_visibility is not None and new_visibility != current_visibility:
+            new_visibility = event.content.get("visibility")
+            current_visibility = prev_rules_event.content.get("visibility")
+            # deny current_visibility updates unless when fix_visibility_access_rules is active
+            if current_visibility is not None and new_visibility is not None and new_visibility != current_visibility and not self.config.fix_visibility_access_rules:
                 return False
 
         new_rule = event.content.get("rule")

--- a/tests/test_event_allowed.py
+++ b/tests/test_event_allowed.py
@@ -736,6 +736,32 @@ class SendEventTestCase(aiounittest.AsyncTestCase):
 
         self.assertFalse(allowed)
 
+    async def test_allow_update_visibility_when_fixer_is_active(self):
+        """Tests that visibility can not be updated"""
+
+        self.module = create_module(
+            {"domains_forbidden_when_restricted": ["forbidden.com"], "fix_visibility_access_rules" : True},
+        )
+        state_events = self.restricted_room_state.copy()
+        state_events[(ACCESS_RULES_TYPE, "")] = new_access_rules_event(
+            self.room_creator,
+            self.restricted_room_state,
+            AccessRules.RESTRICTED,
+            visibility=Visibility.PUBLIC
+        )
+
+        allowed, _ = await self.module.check_event_allowed(
+            event=new_access_rules_event(
+                self.room_creator,
+                self.restricted_room_state,
+                AccessRules.RESTRICTED,
+                visibility=Visibility.PRIVATE,
+            ),
+            state_events=state_events,
+        )
+
+        self.assertTrue(allowed)
+
     async def test_forbid_encryption_on_unencrypted_room(self):
         """Tests that a unencrypted room can't have its encryption enabled."""
         state_events = self.restricted_room_state.copy()


### PR DESCRIPTION
- [add exception when fix_visibility_access_rules is active](https://github.com/tchapgouv/synapse-room-access-rules/pull/17/commits/a61566edb58b1efd27ea3ef6792f93e925727cca)
- [fix: force_unencrypted_at_creation and visibility are optional parameter](https://github.com/tchapgouv/synapse-room-access-rules/pull/17/commits/d8ab69d0c56369043a65283ff97c3c7d2af686f2)