### PR TITLE
Invite by default in public room

### DIFF
--- a/room_access_rules/__init__.py
+++ b/room_access_rules/__init__.py
@@ -585,7 +585,7 @@ class RoomAccessRules(object):
         initial_state[(ACCESS_RULES_TYPE, "")]["content"]["visibility"] = visibility
 
         default_power_levels = self._get_default_power_levels(
-            requester.user.to_string()
+            requester.user.to_string(), preset
         )
 
         # This preset should put all invitees as admin, so do it
@@ -665,7 +665,12 @@ class RoomAccessRules(object):
     #
     # The same power levels are currently applied regardless of room preset.
     @staticmethod
-    def _get_default_power_levels(user_id: str) -> Dict[str, Any]:
+    def _get_default_power_levels(
+        user_id: str,
+        room_creation_preset: str | None = None,
+    ) -> Dict[str, Any]:
+        if room_creation_preset is None:
+            room_creation_preset = RoomCreationPreset.PRIVATE_CHAT
         return {
             "users": {user_id: 100},
             "users_default": 0,
@@ -690,7 +695,9 @@ class RoomAccessRules(object):
             "ban": 50,
             "kick": 50,
             "redact": 50,
-            "invite": 50,  # All rooms should require mod to invite, even private
+            "invite": (
+                0 if room_creation_preset == "public_chat" else 50
+            ),  # Public room allows invite for all whereas other rooms should require mod to invite
         }
 
     async def check_threepid_can_be_invited(
@@ -862,8 +869,14 @@ class RoomAccessRules(object):
         # force_unencrypted_at_creation parameter should never be changed after creation of the room
         if prev_rules_event:
             new_force_unencrypted = event.content.get("force_unencrypted_at_creation")
-            current_force_unencrypted = prev_rules_event.content.get("force_unencrypted_at_creation")
-            if current_force_unencrypted is not None and new_force_unencrypted is not None and new_force_unencrypted != current_force_unencrypted:
+            current_force_unencrypted = prev_rules_event.content.get(
+                "force_unencrypted_at_creation"
+            )
+            if (
+                current_force_unencrypted is not None
+                and new_force_unencrypted is not None
+                and new_force_unencrypted != current_force_unencrypted
+            ):
                 return False
 
         # visibility parameter should never be changed after creation of the room
@@ -871,7 +884,12 @@ class RoomAccessRules(object):
             new_visibility = event.content.get("visibility")
             current_visibility = prev_rules_event.content.get("visibility")
             # deny current_visibility updates unless when fix_visibility_access_rules is active
-            if current_visibility is not None and new_visibility is not None and new_visibility != current_visibility and not self.config.fix_visibility_access_rules:
+            if (
+                current_visibility is not None
+                and new_visibility is not None
+                and new_visibility != current_visibility
+                and not self.config.fix_visibility_access_rules
+            ):
                 return False
 
         new_rule = event.content.get("rule")

--- a/tests/test_create_room.py
+++ b/tests/test_create_room.py
@@ -96,6 +96,19 @@ class RoomCreateTestCase(aiounittest.AsyncTestCase):
         self.assertEqual(pl_override["state_default"], 100, pl_override)
         self.assertEqual(pl_override["invite"], 50, pl_override)
 
+    async def test_create_public_room_default_power_level_rules(self):
+        """Tests that creating a room without overriding the power levels means the module
+        adds default power levels to the room creation config that differ from the default
+        values in the Matrix specification.
+        """
+        config = await self._create_room(public=True)
+
+        self.assertIn("power_level_content_override", config)
+
+        pl_override = config["power_level_content_override"]
+        self.assertEqual(pl_override["state_default"], 100, pl_override)
+        self.assertEqual(pl_override["invite"], 0, pl_override)
+
     async def test_create_room_fails_on_incorrect_power_level_rules(self):
         """Tests that creating a room with a power levels override that would set
         'state_default' and/or 'invite' to values too low to be allowed raises an
@@ -189,17 +202,22 @@ class RoomCreateTestCase(aiounittest.AsyncTestCase):
         rule: str | None = None,
         power_levels_override: Optional[dict] = None,
         initial_state: Optional[list] = None,
+        public: bool = False,
     ) -> Dict[str, Any]:
         config = {
             "is_direct": direct,
-            # TODO handle public
-            "preset": "trusted_private_chat" if direct else "private_chat",
+            "preset": (
+                "trusted_private_chat"
+                if direct
+                else "public_chat" if public else "private_chat"
+            ),
             "initial_state": [],
         }
 
         if rule:
             config["initial_state"] = [
                 {
+                    
                     "type": ACCESS_RULES_TYPE,
                     "state_key": "",
                     "content": {
@@ -219,7 +237,6 @@ class RoomCreateTestCase(aiounittest.AsyncTestCase):
             config=config,
             is_requester_admin=False,
         )
-
         return config
 
     def _check_rule_and_encryption(

--- a/tests/test_event_allowed.py
+++ b/tests/test_event_allowed.py
@@ -721,7 +721,7 @@ class SendEventTestCase(aiounittest.AsyncTestCase):
             self.room_creator,
             self.restricted_room_state,
             AccessRules.RESTRICTED,
-            visibility=Visibility.PUBLIC
+            visibility=Visibility.PUBLIC,
         )
 
         allowed, _ = await self.module.check_event_allowed(
@@ -740,14 +740,17 @@ class SendEventTestCase(aiounittest.AsyncTestCase):
         """Tests that visibility can not be updated"""
 
         self.module = create_module(
-            {"domains_forbidden_when_restricted": ["forbidden.com"], "fix_visibility_access_rules" : True},
+            {
+                "domains_forbidden_when_restricted": ["forbidden.com"],
+                "fix_visibility_access_rules": True,
+            },
         )
         state_events = self.restricted_room_state.copy()
         state_events[(ACCESS_RULES_TYPE, "")] = new_access_rules_event(
             self.room_creator,
             self.restricted_room_state,
             AccessRules.RESTRICTED,
-            visibility=Visibility.PUBLIC
+            visibility=Visibility.PUBLIC,
         )
 
         allowed, _ = await self.module.check_event_allowed(


### PR DESCRIPTION
Avant : dans un salon public, par défault, seuls les modérateurs peuvent inviter des gens.

Après: pour s'aligner avec les clients Element, si on crée un salon avec un preset="public_room", n'importe qui peut inviter des gens dans le salon par défaut.

https://github.com/tchapgouv/tchap-backend/issues/187