### PR TITLE
Use spam checker callbacks

### DIFF
--- a/room_access_rules/__init__.py
+++ b/room_access_rules/__init__.py
@@ -819,8 +819,8 @@ class RoomAccessRules(object):
 
             if event.type == EventTypes.PowerLevels:
                 return self._is_power_level_content_allowed(
-                        event.content, rule, on_room_creation=False
-                    )
+                    event.content, rule, on_room_creation=False
+                )
 
             if (
                 event.type == EventTypes.Member

--- a/room_access_rules/__init__.py
+++ b/room_access_rules/__init__.py
@@ -14,7 +14,17 @@
 # limitations under the License.
 import email.utils
 import logging
-from typing import Any, Awaitable, Callable, Dict, List, Mapping, Optional, Tuple
+from typing import (
+    Any,
+    Awaitable,
+    Callable,
+    Dict,
+    List,
+    Literal,
+    Mapping,
+    Optional,
+    Tuple,
+)
 
 import attr
 from synapse.api.constants import (
@@ -24,6 +34,7 @@ from synapse.api.constants import (
     RoomCreationPreset,
     RoomEncryptionAlgorithms,
 )
+from synapse.api.errors import Codes
 from synapse.events import EventBase
 from synapse.module_api import ModuleApi, UserID
 from synapse.module_api.errors import ConfigError, SynapseError
@@ -109,10 +120,12 @@ class RoomAccessRules(object):
         self.module_api = api
 
         self.module_api.register_third_party_rules_callbacks(
-            check_event_allowed=self.check_event_allowed,
             on_create_room=self.on_create_room,
             check_threepid_can_be_invited=self.check_threepid_can_be_invited,
             check_visibility_can_be_modified=self.check_visibility_can_be_modified,
+        )
+        self.module_api.register_spam_checker_callbacks(
+            check_event_for_spam=self.check_event_for_spam
         )
 
         self.task_scheduler = api._hs.get_task_scheduler()
@@ -759,11 +772,20 @@ class RoomAccessRules(object):
             return True
         return False
 
-    async def check_event_allowed(
+    async def check_event_for_spam(
+        self,
+        event: EventBase,
+    ) -> Literal["NOT_SPAM"] | Codes:
+        state_events = await self.module_api.get_room_state(event.room_id)
+        if await self._check_event_allowed(event, state_events):
+            return "NOT_SPAM"
+        return Codes.FORBIDDEN
+
+    async def _check_event_allowed(
         self,
         event: EventBase,
         state_events: StateMap[EventBase],
-    ) -> Tuple[bool, Optional[Dict[str, Any]]]:
+    ) -> bool:
         """Checks the event's type and the current rule and calls the right function to
         determine whether the event can be allowed.
 
@@ -778,50 +800,44 @@ class RoomAccessRules(object):
             None because this module doesn't replace event contents.
         """
         if await self._user_can_bypass_rules(event.sender):
-            return True, None
+            return True
 
         # We check the rules when altering the state of the room, so only go further if
         # the event is a state event.
         if event.is_state():
             if event.type == ACCESS_RULES_TYPE:
-                return await self._on_rules_change(event, state_events), None
+                return await self._on_rules_change(event, state_events)
 
             # We need to know the rule to apply when processing the event types below.
             rule = self._get_rule_from_state(state_events)
 
             if event.type == EventTypes.PowerLevels:
-                return (
-                    self._is_power_level_content_allowed(
+                return self._is_power_level_content_allowed(
                         event.content, rule, on_room_creation=False
-                    ),
-                    None,
-                )
+                    )
 
             if (
                 event.type == EventTypes.Member
                 or event.type == EventTypes.ThirdPartyInvite
             ):
-                return (
-                    await self._on_membership_or_invite(event, rule, state_events),
-                    None,
-                )
+                return await self._on_membership_or_invite(event, rule, state_events)
 
             if event.type == EventTypes.JoinRules:
-                return self._on_join_rule_change(event, rule, state_events), None
+                return self._on_join_rule_change(event, rule, state_events)
 
             if event.type == EventTypes.RoomAvatar:
-                return self._on_room_avatar_change(event, rule), None
+                return self._on_room_avatar_change(event, rule)
 
             if event.type == EventTypes.Name:
-                return self._on_room_name_change(event, rule), None
+                return self._on_room_name_change(event, rule)
 
             if event.type == EventTypes.Topic:
-                return self._on_room_topic_change(event, rule), None
+                return self._on_room_topic_change(event, rule)
 
             if event.type == EventTypes.RoomEncryption:
-                return self._on_room_encryption_change(event, state_events), None
+                return self._on_room_encryption_change(event, state_events)
 
-        return True, None
+        return True
 
     async def check_visibility_can_be_modified(
         self, room_id: str, state_events: StateMap[EventBase], new_visibility: str

--- a/room_access_rules/__init__.py
+++ b/room_access_rules/__init__.py
@@ -119,6 +119,10 @@ class RoomAccessRules(object):
         self.config = config
         self.module_api = api
 
+        # We keep using check_visibility_can_be_modified because user_may_publish_room
+        # doesn't receive the new visibility state that we need to check.
+        # We keep using on_create_room because user_may_create_room doesn't allow us to
+        # change the initial state (needed to force the encryption or the visibility).
         self.module_api.register_third_party_rules_callbacks(
             on_create_room=self.on_create_room,
             check_visibility_can_be_modified=self.check_visibility_can_be_modified,

--- a/room_access_rules/__init__.py
+++ b/room_access_rules/__init__.py
@@ -121,11 +121,11 @@ class RoomAccessRules(object):
 
         self.module_api.register_third_party_rules_callbacks(
             on_create_room=self.on_create_room,
-            check_threepid_can_be_invited=self.check_threepid_can_be_invited,
             check_visibility_can_be_modified=self.check_visibility_can_be_modified,
         )
         self.module_api.register_spam_checker_callbacks(
-            check_event_for_spam=self.check_event_for_spam
+            check_event_for_spam=self.check_event_for_spam,
+            user_may_send_3pid_invite=self.user_may_send_3pid_invite,
         )
 
         self.task_scheduler = api._hs.get_task_scheduler()
@@ -713,42 +713,44 @@ class RoomAccessRules(object):
             ),  # Public room allows invite for all whereas other rooms should require mod to invite
         }
 
-    async def check_threepid_can_be_invited(
+    async def user_may_send_3pid_invite(
         self,
+        inviter: str,
         medium: str,
         address: str,
-        state_events: StateMap[EventBase],
-    ) -> bool:
+        room_id: str,
+    ) -> Literal["NOT_SPAM"] | Codes:
         """Check if a threepid can be invited to the room via a 3PID invite given the
         current rules and the threepid's address, by retrieving the HS it's mapped to
         from the configured identity server, and checking if we can invite users from it.
 
         Args:
+            inviter: The user ID of the inviter.
             medium: The medium of the threepid.
             address: The address of the threepid.
-            state_events: A dict mapping (event type, state key) to state event.
-                State events in the room the threepid is being invited to.
+            room_id: The ID of the room to check.
 
         Returns:
             Whether the threepid invite is allowed.
         """
+        state_events = await self.module_api.get_room_state(room_id)
         rule = self._get_rule_from_state(state_events)
 
         if medium != "email":
-            return False
+            return Codes.FORBIDDEN
 
         if rule != AccessRules.RESTRICTED:
             # Only "restricted" requires filtering 3PID invites. We don't need to do
             # anything for "direct" here, because only "restricted" requires filtering
             # based on the HS the address is mapped to.
-            return True
+            return "NOT_SPAM"
 
         parsed_address = email.utils.parseaddr(address)[1]
         if parsed_address != address:
             # Avoid reproducing the security issue described here:
             # https://matrix.org/blog/2019/04/18/security-update-sydent-1-0-2
             # It's probably not worth it but let's just be overly safe here.
-            return False
+            return Codes.FORBIDDEN
 
         # Get the HS this address belongs to from the identity server.
         res = await self.module_api.http_client.get_json(
@@ -758,11 +760,11 @@ class RoomAccessRules(object):
 
         # Look for a domain that's not forbidden from being invited.
         if not res.get("hs"):
-            return False
+            return Codes.FORBIDDEN
         if res.get("hs") in self.config.domains_forbidden_when_restricted:
-            return False
+            return Codes.FORBIDDEN
 
-        return True
+        return "NOT_SPAM"
 
     async def _user_can_bypass_rules(self, user_id: str) -> bool:
         if (

--- a/tests/test_create_room.py
+++ b/tests/test_create_room.py
@@ -217,7 +217,6 @@ class RoomCreateTestCase(aiounittest.AsyncTestCase):
         if rule:
             config["initial_state"] = [
                 {
-                    
                     "type": ACCESS_RULES_TYPE,
                     "state_key": "",
                     "content": {

--- a/tests/test_event_allowed.py
+++ b/tests/test_event_allowed.py
@@ -12,8 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from typing import Optional
+from unittest.mock import AsyncMock
 
 import aiounittest
+from synapse.api.errors import Codes
 
 from room_access_rules import (
     ACCESS_RULES_TYPE,
@@ -178,6 +180,10 @@ class SendEventTestCase(aiounittest.AsyncTestCase):
         """Tests that in restricted mode we're unable to invite users from blacklisted
         servers but can invite other users.
         """
+        self.module.module_api.get_room_state = AsyncMock(
+            return_value=self.restricted_room_state
+        )
+
         # Tests that inviting an MXID from a forbidden HS isn't allowed.
         allowed = await self.module._check_event_allowed(
             event=self._new_membership_event(
@@ -208,22 +214,24 @@ class SendEventTestCase(aiounittest.AsyncTestCase):
         # We test this through check_threepid_can_be_invited since this function will be
         # called before check_event_allowed, thus the check on whether the HS is allowed
         # or not happens here.
-        allowed = await self.module.check_threepid_can_be_invited(
+        allowed = await self.module.user_may_send_3pid_invite(
+            self.room_creator,
             medium="email",
             address=self.forbidden_email,
-            state_events=self.restricted_room_state,
+            room_id="!someroom",
         )
 
-        self.assertFalse(allowed)
+        self.assertEqual(allowed, Codes.FORBIDDEN)
 
         # Tests that inviting an email address from an allowed HS is allowed.
-        allowed = await self.module.check_threepid_can_be_invited(
+        allowed = await self.module.user_may_send_3pid_invite(
+            self.room_creator,
             medium="email",
             address=self.allowed_email,
-            state_events=self.restricted_room_state,
+            room_id="!someroom",
         )
 
-        self.assertTrue(allowed)
+        self.assertEqual(allowed, "NOT_SPAM")
 
     async def test_direct(self):
         """Tests that, in direct mode, other users than the initial two can't be invited,
@@ -348,6 +356,10 @@ class SendEventTestCase(aiounittest.AsyncTestCase):
         only change the power level of users that wouldn't be forbidden in restricted
         mode.
         """
+        self.module.module_api.get_room_state = AsyncMock(
+            return_value=self.unrestricted_room_state
+        )
+
         # We can invite
         allowed = await self.module._check_event_allowed(
             event=self._new_membership_event(
@@ -372,22 +384,26 @@ class SendEventTestCase(aiounittest.AsyncTestCase):
         self.assertTrue(allowed)
 
         # We can send a 3PID invite to an address that is mapped to a forbidden HS.
-        self.assertTrue(
-            await self.module.check_threepid_can_be_invited(
+        self.assertEqual(
+            await self.module.user_may_send_3pid_invite(
+                self.room_creator,
                 medium="email",
                 address=self.forbidden_email,
-                state_events=self.unrestricted_room_state,
-            )
+                room_id="!someroom",
+            ),
+            "NOT_SPAM",
         )
 
         # We can send a 3PID invite to an address that is mapped to an HS that's not
         # forbidden.
-        self.assertTrue(
-            await self.module.check_threepid_can_be_invited(
+        self.assertEqual(
+            await self.module.user_may_send_3pid_invite(
+                self.room_creator,
                 medium="email",
                 address=self.allowed_email,
-                state_events=self.unrestricted_room_state,
-            )
+                room_id="!someroom",
+            ),
+            "NOT_SPAM",
         )
 
         # We can send a power level event that doesn't redefine the default PL or set a

--- a/tests/test_event_allowed.py
+++ b/tests/test_event_allowed.py
@@ -162,13 +162,13 @@ class SendEventTestCase(aiounittest.AsyncTestCase):
             content=pl_content,
         )
 
-        allowed, _ = await self.module.check_event_allowed(
+        allowed = await self.module._check_event_allowed(
             event=pl_event,
             state_events=self.direct_room_state,
         )
         self.assertTrue(allowed)
 
-        allowed, _ = await self.module.check_event_allowed(
+        allowed = await self.module._check_event_allowed(
             event=pl_event,
             state_events=self.unrestricted_room_state,
         )
@@ -179,7 +179,7 @@ class SendEventTestCase(aiounittest.AsyncTestCase):
         servers but can invite other users.
         """
         # Tests that inviting an MXID from a forbidden HS isn't allowed.
-        allowed, _ = await self.module.check_event_allowed(
+        allowed = await self.module._check_event_allowed(
             event=self._new_membership_event(
                 self.room_creator,
                 self.forbidden_invitee,
@@ -192,7 +192,7 @@ class SendEventTestCase(aiounittest.AsyncTestCase):
         self.assertFalse(allowed)
 
         # Tests that inviting an MXID from an allowed HS is allowed.
-        allowed, _ = await self.module.check_event_allowed(
+        allowed = await self.module._check_event_allowed(
             event=self._new_membership_event(
                 self.room_creator,
                 self.allowed_invitee,
@@ -236,7 +236,7 @@ class SendEventTestCase(aiounittest.AsyncTestCase):
         in restricted mode) can be invited.
         """
         # Test that a 3rd user can't be invited.
-        allowed, _ = await self.module.check_event_allowed(
+        allowed = await self.module._check_event_allowed(
             event=self._new_membership_event(
                 self.room_creator,
                 self.other_allowed_invitee,
@@ -255,7 +255,7 @@ class SendEventTestCase(aiounittest.AsyncTestCase):
             self.direct_room,
         )
 
-        allowed, _ = await self.module.check_event_allowed(
+        allowed = await self.module._check_event_allowed(
             event=join_event,
             state_events=self.direct_room_state,
         )
@@ -272,7 +272,7 @@ class SendEventTestCase(aiounittest.AsyncTestCase):
             self.direct_room,
         )
 
-        allowed, _ = await self.module.check_event_allowed(
+        allowed = await self.module._check_event_allowed(
             event=leave_event,
             state_events=state_with_join,
         )
@@ -289,7 +289,7 @@ class SendEventTestCase(aiounittest.AsyncTestCase):
             self.direct_room,
         )
 
-        allowed, _ = await self.module.check_event_allowed(
+        allowed = await self.module._check_event_allowed(
             event=invite_event,
             state_events=state_with_leave,
         )
@@ -301,7 +301,7 @@ class SendEventTestCase(aiounittest.AsyncTestCase):
         del state_with_no_invite[(EventTypes.Member, self.allowed_invitee)]
 
         # Test that can't send a 3PID invite to a room that already has two members.
-        allowed, _ = await self.module.check_event_allowed(
+        allowed = await self.module._check_event_allowed(
             event=self._new_membership_event(
                 self.room_creator,
                 self.other_allowed_invitee,
@@ -314,13 +314,13 @@ class SendEventTestCase(aiounittest.AsyncTestCase):
 
         # Test that we can't send a 3PID invite to a room that already has a pending
         # invite.
-        allowed, _ = await self.module.check_event_allowed(
+        allowed = await self.module._check_event_allowed(
             event=self._new_3pid_invite(self.room_creator, self.direct_room),
             state_events=state_with_join,
         )
         self.assertFalse(allowed)
 
-        allowed, _ = await self.module.check_event_allowed(
+        allowed = await self.module._check_event_allowed(
             event=self._new_3pid_invite(self.room_creator, self.direct_room),
             state_events=self.direct_room_state,
         )
@@ -337,7 +337,7 @@ class SendEventTestCase(aiounittest.AsyncTestCase):
 
         # Test that we can't send a 3PID invite to a room in which there's already a 3PID
         # invite.
-        allowed, _ = await self.module.check_event_allowed(
+        allowed = await self.module._check_event_allowed(
             event=self._new_3pid_invite(self.room_creator, self.direct_room),
             state_events=state_with_3pid_invite,
         )
@@ -349,7 +349,7 @@ class SendEventTestCase(aiounittest.AsyncTestCase):
         mode.
         """
         # We can invite
-        allowed, _ = await self.module.check_event_allowed(
+        allowed = await self.module._check_event_allowed(
             event=self._new_membership_event(
                 self.room_creator,
                 self.forbidden_invitee,
@@ -360,7 +360,7 @@ class SendEventTestCase(aiounittest.AsyncTestCase):
         )
         self.assertTrue(allowed)
 
-        allowed, _ = await self.module.check_event_allowed(
+        allowed = await self.module._check_event_allowed(
             event=self._new_membership_event(
                 self.room_creator,
                 self.allowed_invitee,
@@ -392,7 +392,7 @@ class SendEventTestCase(aiounittest.AsyncTestCase):
 
         # We can send a power level event that doesn't redefine the default PL or set a
         # non-default PL for a user that would be forbidden in restricted mode.
-        allowed, _ = await self.module.check_event_allowed(
+        allowed = await self.module._check_event_allowed(
             event=MockEvent(
                 sender=self.room_creator,
                 type=EventTypes.PowerLevels,
@@ -408,7 +408,7 @@ class SendEventTestCase(aiounittest.AsyncTestCase):
 
         # We can't send a power level event that redefines the default PL and doesn't set
         # a non-default PL for a user that would be forbidden in restricted mode.
-        allowed, _ = await self.module.check_event_allowed(
+        allowed = await self.module._check_event_allowed(
             event=MockEvent(
                 sender=self.room_creator,
                 type=EventTypes.PowerLevels,
@@ -425,7 +425,7 @@ class SendEventTestCase(aiounittest.AsyncTestCase):
 
         # We can't send a power level event that doesn't redefines the default PL but sets
         # a non-default PL for a user that would be forbidden in restricted mode.
-        allowed, _ = await self.module.check_event_allowed(
+        allowed = await self.module._check_event_allowed(
             event=MockEvent(
                 sender=self.room_creator,
                 type=EventTypes.PowerLevels,
@@ -445,7 +445,7 @@ class SendEventTestCase(aiounittest.AsyncTestCase):
         unrestricted.
         """
         # We can't change the rule from restricted to direct.
-        allowed, _ = await self.module.check_event_allowed(
+        allowed = await self.module._check_event_allowed(
             event=new_access_rules_event(
                 self.room_creator,
                 self.restricted_room,
@@ -456,7 +456,7 @@ class SendEventTestCase(aiounittest.AsyncTestCase):
         self.assertFalse(allowed)
 
         # We can change the rule from restricted to unrestricted.
-        allowed, _ = await self.module.check_event_allowed(
+        allowed = await self.module._check_event_allowed(
             event=new_access_rules_event(
                 self.room_creator,
                 self.restricted_room,
@@ -467,7 +467,7 @@ class SendEventTestCase(aiounittest.AsyncTestCase):
         self.assertTrue(allowed)
 
         # We can't change the rule from unrestricted to restricted.
-        allowed, _ = await self.module.check_event_allowed(
+        allowed = await self.module._check_event_allowed(
             event=new_access_rules_event(
                 self.room_creator,
                 self.unrestricted_room,
@@ -478,7 +478,7 @@ class SendEventTestCase(aiounittest.AsyncTestCase):
         self.assertFalse(allowed)
 
         # We can't change the rule from unrestricted to direct.
-        allowed, _ = await self.module.check_event_allowed(
+        allowed = await self.module._check_event_allowed(
             event=new_access_rules_event(
                 self.room_creator,
                 self.unrestricted_room,
@@ -489,7 +489,7 @@ class SendEventTestCase(aiounittest.AsyncTestCase):
         self.assertFalse(allowed)
 
         # We can't change the rule from direct to restricted.
-        allowed, _ = await self.module.check_event_allowed(
+        allowed = await self.module._check_event_allowed(
             event=new_access_rules_event(
                 self.room_creator,
                 self.direct_room,
@@ -499,7 +499,7 @@ class SendEventTestCase(aiounittest.AsyncTestCase):
         )
         self.assertFalse(allowed)
 
-        allowed, _ = await self.module.check_event_allowed(
+        allowed = await self.module._check_event_allowed(
             event=new_access_rules_event(
                 self.room_creator,
                 self.direct_room,
@@ -588,7 +588,7 @@ class SendEventTestCase(aiounittest.AsyncTestCase):
             invite_content,
         )
 
-        allowed, _ = await self.module.check_event_allowed(
+        allowed = await self.module._check_event_allowed(
             event=invite_event,
             state_events=state_events,
         )
@@ -608,7 +608,7 @@ class SendEventTestCase(aiounittest.AsyncTestCase):
             {},
         )
 
-        allowed, _ = await self.module.check_event_allowed(
+        allowed = await self.module._check_event_allowed(
             event=invite_event,
             state_events=state_events,
         )
@@ -629,7 +629,7 @@ class SendEventTestCase(aiounittest.AsyncTestCase):
             "someothertoken",
         )
 
-        allowed, _ = await self.module.check_event_allowed(
+        allowed = await self.module._check_event_allowed(
             event=invite_event,
             state_events=state_events,
         )
@@ -652,7 +652,7 @@ class SendEventTestCase(aiounittest.AsyncTestCase):
             state_key="",
         )
 
-        allowed, _ = await self.module.check_event_allowed(
+        allowed = await self.module._check_event_allowed(
             event=MockEvent(
                 sender=self.room_creator,
                 type=EventTypes.JoinRules,
@@ -680,7 +680,7 @@ class SendEventTestCase(aiounittest.AsyncTestCase):
             state_key="",
         )
 
-        allowed, _ = await self.module.check_event_allowed(
+        allowed = await self.module._check_event_allowed(
             event=MockEvent(
                 sender=self.room_creator,
                 type=EventTypes.RoomEncryption,
@@ -702,7 +702,7 @@ class SendEventTestCase(aiounittest.AsyncTestCase):
             force_unencrypted_at_creation=False,
         )
 
-        allowed, _ = await self.module.check_event_allowed(
+        allowed = await self.module._check_event_allowed(
             event=new_access_rules_event(
                 self.room_creator,
                 self.restricted_room_state,
@@ -724,7 +724,7 @@ class SendEventTestCase(aiounittest.AsyncTestCase):
             visibility=Visibility.PUBLIC,
         )
 
-        allowed, _ = await self.module.check_event_allowed(
+        allowed = await self.module._check_event_allowed(
             event=new_access_rules_event(
                 self.room_creator,
                 self.restricted_room_state,
@@ -733,11 +733,10 @@ class SendEventTestCase(aiounittest.AsyncTestCase):
             ),
             state_events=state_events,
         )
-
         self.assertFalse(allowed)
 
     async def test_allow_update_visibility_when_fixer_is_active(self):
-        """Tests that visibility can not be updated"""
+        """Tests that visibility can be updated"""
 
         self.module = create_module(
             {
@@ -753,7 +752,7 @@ class SendEventTestCase(aiounittest.AsyncTestCase):
             visibility=Visibility.PUBLIC,
         )
 
-        allowed, _ = await self.module.check_event_allowed(
+        allowed = await self.module._check_event_allowed(
             event=new_access_rules_event(
                 self.room_creator,
                 self.restricted_room_state,
@@ -775,7 +774,7 @@ class SendEventTestCase(aiounittest.AsyncTestCase):
             force_unencrypted_at_creation=True,
         )
 
-        allowed, _ = await self.module.check_event_allowed(
+        allowed = await self.module._check_event_allowed(
             event=MockEvent(
                 sender=self.room_creator,
                 type=EventTypes.RoomEncryption,
@@ -816,11 +815,11 @@ class SendEventTestCase(aiounittest.AsyncTestCase):
         )
 
         # Check that a forbidden user cannot join a restricted room, even with an invite.
-        allowed, _ = await self.module.check_event_allowed(forbidden_join, state_events)
+        allowed = await self.module._check_event_allowed(forbidden_join, state_events)
         self.assertFalse(allowed)
 
         # Check that an allowed user can join a restricted room, even without an invite.
-        allowed, _ = await self.module.check_event_allowed(
+        allowed = await self.module._check_event_allowed(
             event=allowed_join,
             state_events=self.restricted_room_state,
         )
@@ -828,7 +827,7 @@ class SendEventTestCase(aiounittest.AsyncTestCase):
 
         # Check that a forbidden user cannot join an unrestricted room if they haven't
         # been invited into it.
-        allowed, _ = await self.module.check_event_allowed(
+        allowed = await self.module._check_event_allowed(
             event=forbidden_join,
             state_events=self.unrestricted_room_state,
         )
@@ -845,7 +844,7 @@ class SendEventTestCase(aiounittest.AsyncTestCase):
 
         # Check that a forbidden user can join an unrestricted room if they have been
         # invited into it.
-        allowed, _ = await self.module.check_event_allowed(
+        allowed = await self.module._check_event_allowed(
             event=forbidden_join,
             state_events=state_events,
         )
@@ -862,7 +861,7 @@ class SendEventTestCase(aiounittest.AsyncTestCase):
         )
 
         # the existing join rule is "public" and the room is not encrypted
-        allowed, _ = await self.module.check_event_allowed(
+        allowed = await self.module._check_event_allowed(
             event=MockEvent(
                 sender=self.room_creator,
                 type=EventTypes.JoinRules,
@@ -874,7 +873,7 @@ class SendEventTestCase(aiounittest.AsyncTestCase):
         self.assertFalse(allowed)
 
         # the existing join rule is "public" and the room is encrypted
-        allowed, _ = await self.module.check_event_allowed(
+        allowed = await self.module._check_event_allowed(
             event=MockEvent(
                 sender=self.room_creator,
                 type=EventTypes.JoinRules,
@@ -928,19 +927,19 @@ class SendEventTestCase(aiounittest.AsyncTestCase):
         )
 
     async def _test_allowed_except_direct(self, event: MockEvent):
-        allowed, _ = await self.module.check_event_allowed(
+        allowed = await self.module._check_event_allowed(
             event=event,
             state_events=self.restricted_room_state,
         )
         self.assertTrue(allowed)
 
-        allowed, _ = await self.module.check_event_allowed(
+        allowed = await self.module._check_event_allowed(
             event=event,
             state_events=self.unrestricted_room_state,
         )
         self.assertTrue(allowed)
 
-        allowed, _ = await self.module.check_event_allowed(
+        allowed = await self.module._check_event_allowed(
             event=event,
             state_events=self.direct_room_state,
         )

--- a/tests/test_visibility.py
+++ b/tests/test_visibility.py
@@ -40,7 +40,7 @@ class RoomVisibilityTestCase(aiounittest.AsyncTestCase):
         }
 
         # Check that we can't change the rule to 'unrestricted'.
-        allowed, _ = await self.module.check_event_allowed(
+        allowed = await self.module._check_event_allowed(
             event=new_access_rules_event(
                 self.user_id,
                 PUBLIC_ROOM_ID,
@@ -53,7 +53,7 @@ class RoomVisibilityTestCase(aiounittest.AsyncTestCase):
         self.assertFalse(allowed)
 
         # Check that we can't change the rule to 'direct'.
-        allowed, _ = await self.module.check_event_allowed(
+        allowed = await self.module._check_event_allowed(
             event=new_access_rules_event(
                 self.user_id,
                 PUBLIC_ROOM_ID,


### PR DESCRIPTION
check_event_for_spam is not called during room creation, which is what we want here.

rationale:
- on passe pas dans `check_event_for_spam` a la création de room
- `check_event_for_spam` va rejeter les events au niveau de l'API client, mais pour la fed ca va les soft fail à la place (l'event existe toujours mais est globalement ignoré et pas transmis au clients)
- `check_allowed_event` on y passe à la création de room, et en plus ca rejete au niveau de la fed au lieu de faire un soft fail => on va splitbrain des rooms quand on ouvrira la fed avec des gens qui n'ont pas le module
- ~~y'a `user_may_create_room` dans le spam checker, et pour les meme raisons vaut mieux utiliser ca que `on_create_room`.~~ on utilise pas user_may_create_room car on ne peut alors pas modifier le initial state, on en a besoin pour pouvoir forcer le chiffrement et ajouter notre event custom
- ca n'enlève pas le fait que on va avoir le custom event de room creation qui arrive par la fed et passe dans `check_event_for_spam`. Cependant on a un easy workaround : on check le `sender`, et si il est pas local on laisse passer la création de l'event. on pourra pas faire mieux je pense, on ne peut pas avoir l'info de si c'est la room creation via la fed.

Untested for now.